### PR TITLE
Release v2.0.1 (post-merge fixes)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,12 +15,12 @@ jobs:
         run: sudo apt-get install -y shellcheck
       - name: Syntax check (bash -n)
         run: |
-          bash -n files/bfd files/internals/bfd.lib.sh files/internals/elog_lib.sh files/internals/alert_lib.sh files/internals/bfd_alert.sh files/internals/pkg_lib.sh files/internals/geoip_lib.sh files/tlog files/internals/tlog_lib.sh files/update-ipcountry.sh
+          bash -n files/bfd files/internals/bfd.lib.sh files/internals/elog_lib.sh files/internals/alert_lib.sh files/internals/bfd_alert.sh files/internals/pkg_lib.sh files/internals/geoip_lib.sh files/internals/bfd_report.sh files/tlog files/internals/tlog_lib.sh files/update-ipcountry.sh
           bash -n install.sh uninstall.sh importconf cron.daily bfd-watch.init
           bash -n pkg/deb/debian/bfd.preinst pkg/deb/debian/bfd.postinst pkg/deb/debian/bfd.prerm pkg/deb/debian/bfd.postrm
       - name: Shellcheck main scripts
         run: |
-          shellcheck -S warning files/bfd files/internals/bfd.lib.sh files/internals/elog_lib.sh files/internals/alert_lib.sh files/internals/bfd_alert.sh files/internals/pkg_lib.sh files/internals/geoip_lib.sh files/tlog files/internals/tlog_lib.sh files/update-ipcountry.sh
+          shellcheck -S warning files/bfd files/internals/bfd.lib.sh files/internals/elog_lib.sh files/internals/alert_lib.sh files/internals/bfd_alert.sh files/internals/pkg_lib.sh files/internals/geoip_lib.sh files/internals/bfd_report.sh files/tlog files/internals/tlog_lib.sh files/update-ipcountry.sh
           shellcheck -S warning install.sh uninstall.sh importconf cron.daily bfd-watch.init
           shellcheck -S warning pkg/deb/debian/bfd.preinst pkg/deb/debian/bfd.postinst pkg/deb/debian/bfd.prerm pkg/deb/debian/bfd.postrm
           shellcheck -S warning -s bash --exclude=SC2207 bfd.bash-completion

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,10 @@
 [New] CIDR subnet ban alerts enriched with aggregate pressure and failure stats
 [New] Contributing hosts breakdown in all alert channels (email, Slack, Telegram, Discord)
 [Fix] CIDR alert pipeline fields 4 and 13 now carry real aggregate values (was broken)
+[Fix] Packaging: cron.daily keeps /usr/local/bfd INSTALL_PATH in FHS packages
+      (symlink farm provides the indirection; /var/lib/bfd has no conf.bfd or bfd)
+[Fix] Packaging: alert template count assertion updated from 14 to 21
+[Fix] Packaging: DEB changelog rule count corrected from 42 to 57
 [New] Pressure-to-response scoring model: exponential-decay replaces fixed
       count thresholds; per-rule weights, trip points, and half-life via
       pressure.conf; cross-service aggregate trip; old TRIG/TRIG_WINDOW

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,6 +9,7 @@
       (symlink farm provides the indirection; /var/lib/bfd has no conf.bfd or bfd)
 [Fix] Packaging: alert template count assertion updated from 14 to 21
 [Fix] Packaging: DEB changelog rule count corrected from 42 to 57
+[Fix] CI: add bfd_report.sh to bash -n and shellcheck lint targets
 [New] Pressure-to-response scoring model: exponential-decay replaces fixed
       count thresholds; per-rule weights, trip points, and half-life via
       pressure.conf; cross-service aggregate trip; old TRIG/TRIG_WINDOW

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -20,6 +20,8 @@
       fix template variable names in variable table
 [Fix] usage_short() output line split to fit 80 columns
 [Fix] conf.bfd EMAIL_LOGLINES comment: add "and event view"
+[Fix] cron.daily sources internals.conf for correct LOCK_FILE in FHS packages
+      (lock.utime is at /var/lib/bfd/ not /usr/local/bfd/ after pkg transform)
 [New] Pressure-to-response scoring model: exponential-decay replaces fixed
       count thresholds; per-rule weights, trip points, and half-life via
       pressure.conf; cross-service aggregate trip; old TRIG/TRIG_WINDOW

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -15,6 +15,11 @@
       COUNTRY_FLAG, SOURCE_LOGS_SECTION_TEXT, REPUTATION_SECTION_TEXT);
       add --sort, --limit, --24h/--7d/--30d, --active to SYNOPSIS modifiers;
       update .TH date to 2026-03-17
+[Fix] README: promote Periodic Reports to top-level section (§7.1→§8),
+      renumber sections 8-12→9-13, update TOC and cross-references;
+      fix template variable names in variable table
+[Fix] usage_short() output line split to fit 80 columns
+[Fix] conf.bfd EMAIL_LOGLINES comment: add "and event view"
 [New] Pressure-to-response scoring model: exponential-decay replaces fixed
       count thresholds; per-rule weights, trip points, and half-life via
       pressure.conf; cross-service aggregate trip; old TRIG/TRIG_WINDOW

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -10,6 +10,11 @@
 [Fix] Packaging: alert template count assertion updated from 14 to 21
 [Fix] Packaging: DEB changelog rule count corrected from 42 to 57
 [Fix] CI: add bfd_report.sh to bash -n and shellcheck lint targets
+[Fix] Man page: add --ban, --unban, --events, --test long forms to OPTIONS;
+      fix template variable names (FAIL_COUNT_DISPLAY, BAN_DURATION_DETAIL,
+      COUNTRY_FLAG, SOURCE_LOGS_SECTION_TEXT, REPUTATION_SECTION_TEXT);
+      add --sort, --limit, --24h/--7d/--30d, --active to SYNOPSIS modifiers;
+      update .TH date to 2026-03-17
 [New] Pressure-to-response scoring model: exponential-decay replaces fixed
       count thresholds; per-rule weights, trip points, and half-life via
       pressure.conf; cross-service aggregate trip; old TRIG/TRIG_WINDOW

--- a/CHANGELOG.RELEASE
+++ b/CHANGELOG.RELEASE
@@ -5,6 +5,10 @@
 [New] CIDR subnet ban alerts enriched with aggregate pressure and failure stats
 [New] Contributing hosts breakdown in all alert channels (email, Slack, Telegram, Discord)
 [Fix] CIDR alert pipeline fields 4 and 13 now carry real aggregate values (was broken)
+[Fix] Packaging: cron.daily keeps /usr/local/bfd INSTALL_PATH in FHS packages
+      (symlink farm provides the indirection; /var/lib/bfd has no conf.bfd or bfd)
+[Fix] Packaging: alert template count assertion updated from 14 to 21
+[Fix] Packaging: DEB changelog rule count corrected from 42 to 57
 [New] Pressure-to-response scoring model: exponential-decay replaces fixed
       count thresholds; per-rule weights, trip points, and half-life via
       pressure.conf; cross-service aggregate trip; old TRIG/TRIG_WINDOW

--- a/CHANGELOG.RELEASE
+++ b/CHANGELOG.RELEASE
@@ -9,6 +9,7 @@
       (symlink farm provides the indirection; /var/lib/bfd has no conf.bfd or bfd)
 [Fix] Packaging: alert template count assertion updated from 14 to 21
 [Fix] Packaging: DEB changelog rule count corrected from 42 to 57
+[Fix] CI: add bfd_report.sh to bash -n and shellcheck lint targets
 [New] Pressure-to-response scoring model: exponential-decay replaces fixed
       count thresholds; per-rule weights, trip points, and half-life via
       pressure.conf; cross-service aggregate trip; old TRIG/TRIG_WINDOW

--- a/CHANGELOG.RELEASE
+++ b/CHANGELOG.RELEASE
@@ -20,6 +20,8 @@
       fix template variable names in variable table
 [Fix] usage_short() output line split to fit 80 columns
 [Fix] conf.bfd EMAIL_LOGLINES comment: add "and event view"
+[Fix] cron.daily sources internals.conf for correct LOCK_FILE in FHS packages
+      (lock.utime is at /var/lib/bfd/ not /usr/local/bfd/ after pkg transform)
 [New] Pressure-to-response scoring model: exponential-decay replaces fixed
       count thresholds; per-rule weights, trip points, and half-life via
       pressure.conf; cross-service aggregate trip; old TRIG/TRIG_WINDOW

--- a/CHANGELOG.RELEASE
+++ b/CHANGELOG.RELEASE
@@ -15,6 +15,11 @@
       COUNTRY_FLAG, SOURCE_LOGS_SECTION_TEXT, REPUTATION_SECTION_TEXT);
       add --sort, --limit, --24h/--7d/--30d, --active to SYNOPSIS modifiers;
       update .TH date to 2026-03-17
+[Fix] README: promote Periodic Reports to top-level section (§7.1→§8),
+      renumber sections 8-12→9-13, update TOC and cross-references;
+      fix template variable names in variable table
+[Fix] usage_short() output line split to fit 80 columns
+[Fix] conf.bfd EMAIL_LOGLINES comment: add "and event view"
 [New] Pressure-to-response scoring model: exponential-decay replaces fixed
       count thresholds; per-rule weights, trip points, and half-life via
       pressure.conf; cross-service aggregate trip; old TRIG/TRIG_WINDOW

--- a/CHANGELOG.RELEASE
+++ b/CHANGELOG.RELEASE
@@ -10,6 +10,11 @@
 [Fix] Packaging: alert template count assertion updated from 14 to 21
 [Fix] Packaging: DEB changelog rule count corrected from 42 to 57
 [Fix] CI: add bfd_report.sh to bash -n and shellcheck lint targets
+[Fix] Man page: add --ban, --unban, --events, --test long forms to OPTIONS;
+      fix template variable names (FAIL_COUNT_DISPLAY, BAN_DURATION_DETAIL,
+      COUNTRY_FLAG, SOURCE_LOGS_SECTION_TEXT, REPUTATION_SECTION_TEXT);
+      add --sort, --limit, --24h/--7d/--30d, --active to SYNOPSIS modifiers;
+      update .TH date to 2026-03-17
 [New] Pressure-to-response scoring model: exponential-decay replaces fixed
       count thresholds; per-rule weights, trip points, and half-life via
       pressure.conf; cross-service aggregate trip; old TRIG/TRIG_WINDOW

--- a/README.md
+++ b/README.md
@@ -1,15 +1,17 @@
 # Brute Force Detection (BFD)
 
+[![CI](https://github.com/rfxn/brute-force-detection/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/rfxn/brute-force-detection/actions/workflows/ci.yml)
 [![Version](https://img.shields.io/badge/version-2.0.1-blue.svg)](CHANGELOG)
 [![License: GPL v2](https://img.shields.io/badge/license-GPL_v2-green.svg)](COPYING.GPL)
+[![Shell](https://img.shields.io/badge/language-bash-89e051.svg)](https://www.gnu.org/software/bash/)
+[![Platform](https://img.shields.io/badge/platform-linux-lightgrey.svg)](README.md#11-supported-systems)
 
-**Log-based brute force attack detection and IP banning for Linux servers** — pressure-based
-scoring that lets humans make mistakes while stopping bots cold, automatic ban lifecycle,
-and IPv4/IPv6 support across 57 service rules.
+Log-based brute force detection and automatic IP banning for Linux servers.
+Pressure-based scoring lets humans make mistakes while stopping bots cold —
+57 service rules, 8 firewall backends, IPv4/IPv6, GeoIP enrichment,
+multi-channel alerting, and continuous watch mode with ~10s detection latency.
 
-> (C) 1999-2026, R-fx Networks &lt;proj@rfxn.com&gt;<br>
-> (C) 2026, Ryan MacDonald &lt;ryan@rfxn.com&gt;<br>
-> Licensed under [GNU GPL v2](COPYING.GPL)
+*Copyright (C) 1999-2026 [R-fx Networks](https://www.rfxn.com) · Ryan MacDonald · [GPL v2](COPYING.GPL)*
 
 ---
 
@@ -48,12 +50,12 @@ and IPv4/IPv6 support across 57 service rules.
   - [6.1 Rule Catalog](#61-rule-catalog)
   - [6.2 Rule Customization](#62-rule-customization)
 - [7. Ignore Lists](#7-ignore-lists)
-  - [7.1 Periodic Reports](#71-periodic-reports)
-- [8. Ban Management](#8-ban-management)
-- [9. IPv6 Support](#9-ipv6-support)
-- [10. Troubleshooting](#10-troubleshooting)
-- [11. License](#11-license)
-- [12. Support](#12-support)
+- [8. Periodic Reports](#8-periodic-reports)
+- [9. Ban Management](#9-ban-management)
+- [10. IPv6 Support](#10-ipv6-support)
+- [11. Troubleshooting](#11-troubleshooting)
+- [12. License](#12-license)
+- [13. Support](#13-support)
 
 ---
 
@@ -316,7 +318,7 @@ These four settings form a pipeline: `BAN_ESCALATION` controls how ban duration 
 | `BAN_COMMAND_V6` | *(empty)* | IPv6-specific ban command. When empty, `BAN_COMMAND` is used for both address families |
 | `UNBAN_COMMAND_V6` | *(empty)* | IPv6-specific unban command. When empty, `UNBAN_COMMAND` is used for both |
 
-Leave empty when using tools that handle both protocols natively (nft with `inet` family, APF, ip route). Set explicitly for tools that require separate IPv4/IPv6 commands (iptables/ip6tables). See [section 9](#9-ipv6-support).
+Leave empty when using tools that handle both protocols natively (nft with `inet` family, APF, ip route). Set explicitly for tools that require separate IPv4/IPv6 commands (iptables/ip6tables). See [section 10](#10-ipv6-support).
 
 ### 3.6 Log Paths
 
@@ -422,13 +424,13 @@ To customize, copy the desired partial(s) into `alert/custom.d/` and edit the co
 | `{{HOST}}` | `192.0.2.1` | Banned IP address |
 | `{{SERVICE}}` | `sshd` | Service name |
 | `{{PRESSURE}}` | `21.4` | Pressure score |
-| `{{FAIL_COUNT}}` | `7` | Failed login attempts detected this cycle |
+| `{{FAIL_COUNT_DISPLAY}}` | `7` | Failed login attempts detected this cycle |
 | `{{BAN_TYPE}}` | `Temporary` | Ban type (Temporary/Permanent/Escalated) |
-| `{{BAN_DURATION}}` | `10m` | Human-readable duration |
-| `{{COUNTRY_CODE}}` | `CN` | 2-letter country code |
+| `{{BAN_DURATION_DETAIL}}` | `10m` | Human-readable duration |
+| `{{COUNTRY_FLAG}}` | `CN` | 2-letter country code |
 | `{{COUNTRY_DISPLAY}}` | `China (CN)` | Country name with code (degrades to bare code) |
-| `{{SOURCE_LOGS}}` | *(log lines)* | Sanitized source log excerpt |
-| `{{REPUTATION_LINKS_TEXT}}` | `AbuseIPDB: https://...` | Text-format reputation links |
+| `{{SOURCE_LOGS_SECTION_TEXT}}` | *(log lines)* | Sanitized source log excerpt |
+| `{{REPUTATION_SECTION_TEXT}}` | `AbuseIPDB: https://...` | Text-format reputation links |
 
 See the shipped template files for the complete variable reference.
 
@@ -443,7 +445,7 @@ Messaging channels (Slack, Telegram, Discord) have their own template partials:
 | `discord.message.tpl` | Discord embed JSON wrapper |
 | `discord.entry.tpl` | Discord per-ban embed field |
 
-Periodic reports (see [section 7.1](#71-periodic-reports)) use their own template partials:
+Periodic reports (see [section 8](#8-periodic-reports)) use their own template partials:
 
 | File | Description |
 |------|-------------|
@@ -865,7 +867,9 @@ BFD provides two mechanisms for excluding addresses from bans:
 
 BFD automatically detects local IPv4 and IPv6 addresses (including `::1`) and excludes them from bans. No manual configuration is needed for local address exclusion.
 
-### 7.1 Periodic Reports
+---
+
+## 8. Periodic Reports
 
 BFD can generate scheduled threat reports delivered via all configured alerting channels (email, Slack, Telegram, Discord):
 
@@ -896,7 +900,7 @@ When `REPORT_ENABLED=1`, `cron.daily` triggers daily reports every day, weekly r
 
 ---
 
-## 8. Ban Management
+## 9. Ban Management
 
 Bans can be temporary (auto-expire after `BAN_TTL` seconds) or permanent (`BAN_TTL=0`). Temporary bans require `UNBAN_COMMAND` to be set for the firewall rule to be removed automatically on expiry.
 
@@ -928,7 +932,7 @@ Both `bfd -a` (threat activity) and `bfd -e` (events) read from the attack pool.
 
 ---
 
-## 9. IPv6 Support
+## 10. IPv6 Support
 
 BFD detects and bans both IPv4 and IPv6 addresses automatically. Rules do not need modification — the extraction engine handles both address families. IPv6 addresses are normalized before counting and comparison.
 
@@ -945,7 +949,7 @@ Local IPv6 addresses (including `::1` and all link-local addresses) are auto-det
 
 ---
 
-## 10. Troubleshooting
+## 11. Troubleshooting
 
 Run `bfd -c` first — it validates config, log paths, firewall binaries, rule status, state directories, and active bans in a single non-destructive check.
 
@@ -960,7 +964,7 @@ Run `bfd -c` first — it validates config, log paths, firewall binaries, rule s
 
 ---
 
-## 11. License
+## 12. License
 
 BFD is developed and supported on a volunteer basis by Ryan MacDonald [ryan@rfxn.com].
 
@@ -968,7 +972,7 @@ BFD (Brute Force Detection) is distributed under the GNU General Public License 
 
 ---
 
-## 12. Support
+## 13. Support
 
 The BFD source repository is at: https://github.com/rfxn/brute-force-detection
 

--- a/bfd.1
+++ b/bfd.1
@@ -3,7 +3,7 @@
 .\" Copyright (C) 2026, Ryan MacDonald <ryan@rfxn.com>
 .\" Licensed under the GNU General Public License v2
 .\"
-.TH BFD 1 "2026-03-08" "BFD 2.0.1" "Brute Force Detection"
+.TH BFD 1 "2026-03-17" "BFD 2.0.1" "Brute Force Detection"
 .SH NAME
 bfd \- brute force detection and IP banning
 .SH SYNOPSIS
@@ -55,6 +55,10 @@ bfd \- brute force detection and IP banning
 .B bfd
 .RB [ \-\-json ]
 .RB [ \-\-csv ]
+.RB [ \-\-sort= \fIMODE\fR]
+.RB [ \-\-limit= \fIN\fR]
+.RB [ \-\-24h | \-\-7d | \-\-30d ]
+.RB [ \-\-active ]
 .RB [ \-V | \-\-verbose ]
 .br
 .B bfd
@@ -115,14 +119,14 @@ for configuration reload and
 for clean shutdown.
 .SS Ban Management
 .TP
-.BI \-b " IP" "\fR [" SERVICE \fR]
+.BI \-b ", " \-\-ban " IP" "\fR [" SERVICE \fR]
 Manually ban an IP address (permanent).
 If
 .I SERVICE
 is given, it is recorded as the triggering rule; otherwise
 .BR manual .
 .TP
-.BI \-u " IP"
+.BI \-u ", " \-\-unban " IP"
 Unban an IP address (removes from firewall and active bans).
 .TP
 .B \-\-flush\-temp
@@ -192,7 +196,7 @@ to review aggregate threat patterns and
 .B \-e
 to drill into specific IPs or subnets.
 .TP
-.BI \-e " \fR[" IP | CIDR "\fR] [" N \fR]
+.BI \-e ", " \-\-events " \fR[" IP | CIDR "\fR] [" N \fR]
 Event history and investigation.
 Reads from the attack pool, which records all detected auth failures
 (both ban-triggering and sub-trip observations) with configurable retention
@@ -273,7 +277,7 @@ Validates configuration, binaries, rules, state files, and alert
 capability.
 .SS Testing
 .TP
-.BI \-T " RULE" "\fR [" FILE | \- \fR]
+.BI \-T ", " \-\-test " RULE" "\fR [" FILE | \- \fR]
 Test a rule's patterns against its configured log file, a specific
 .IR FILE ,
 or stdin
@@ -811,13 +815,13 @@ Available template variables include:
 .B {{HOST}}\fR,
 .B {{SERVICE}}\fR,
 .B {{PRESSURE}}\fR,
-.B {{FAIL_COUNT}}\fR,
+.B {{FAIL_COUNT_DISPLAY}}\fR,
 .B {{BAN_TYPE}}\fR,
-.B {{BAN_DURATION}}\fR,
-.B {{COUNTRY_CODE}}\fR,
+.B {{BAN_DURATION_DETAIL}}\fR,
+.B {{COUNTRY_FLAG}}\fR,
 .B {{COUNTRY_DISPLAY}}\fR,
-.B {{SOURCE_LOGS}}\fR,
-.B {{REPUTATION_LINKS_TEXT}}\fR,
+.B {{SOURCE_LOGS_SECTION_TEXT}}\fR,
+.B {{REPUTATION_SECTION_TEXT}}\fR,
 and others.
 See the shipped template files for the full set.
 .SS Messaging Templates

--- a/cron.daily
+++ b/cron.daily
@@ -20,7 +20,21 @@
 ###
 #
 INSTALL_PATH="${INSTALL_PATH:-/usr/local/bfd}"
-LOCK_FILE="$INSTALL_PATH/lock.utime"
+
+# source internals.conf for LOCK_FILE and derived paths (FHS packages
+# transform LOCK_FILE to /var/lib/bfd/lock.utime via internals.conf)
+_int_conf="$INSTALL_PATH/internals/internals.conf"
+if [ -f "$_int_conf" ]; then
+	_int_owner=$(stat -L -c '%u' "$_int_conf" 2>/dev/null)
+	_int_perms=$(stat -L -c '%a' "$_int_conf" 2>/dev/null)
+	if [ "${_int_owner:-}" = "0" ] && \
+	   [ "$(( ${_int_perms:1:1} & 2 ))" -eq 0 ] 2>/dev/null && \
+	   [ "$(( ${_int_perms: -1} & 2 ))" -eq 0 ] 2>/dev/null; then
+		# shellcheck disable=SC1090
+		. "$_int_conf"
+	fi
+fi
+LOCK_FILE="${LOCK_FILE:-$INSTALL_PATH/lock.utime}"
 
 # check if bfd is actively running (mkdir-based lock used by bfd/watch)
 if [ -d "$LOCK_FILE.lk" ]; then

--- a/files/bfd
+++ b/files/bfd
@@ -1398,7 +1398,8 @@ usage_short() {
 	echo "  bfd --test-alert TYPE   send test alert (email|slack|telegram|discord)"
 	echo "  bfd --scan [RULE]   full-log scan (all or specific rule)"
 	echo ""
-	echo "Output modifiers:    --json  --csv  --sort=  --limit=  --24h  --7d  --30d  --active  -V"
+	echo "Output modifiers:    --json  --csv  --sort=  --limit=  --24h  --7d  --30d"
+	echo "                     --active  -V"
 	echo ""
 	echo "Run 'bfd -h' for full option list, or 'man bfd' for documentation."
 }

--- a/files/conf.bfd
+++ b/files/conf.bfd
@@ -50,7 +50,7 @@ EMAIL_ADDRESS="root"
 # alert subject line ($HOSTNAME expands at runtime)
 EMAIL_SUBJECT="Brute Force Warning for $HOSTNAME"
 
-# log lines from the offending service included in each alert; must be > 0
+# log lines from the offending service included in each alert and event view; must be > 0
 EMAIL_LOGLINES="5"
 
 # email body format [text = plain text, html = HTML only, both = multipart text+HTML]

--- a/pkg/deb/debian/changelog
+++ b/pkg/deb/debian/changelog
@@ -4,7 +4,7 @@ bfd (2.0.1-1) unstable; urgency=medium
   * Pressure model with exponential-decay scoring
   * 8 firewall backends with auto-detection
   * Watch mode daemon with ~10s detection latency
-  * 42 service detection rules
+  * 57 service detection rules
   * Country-based pressure multipliers
 
  -- R-fx Networks <proj@rfxn.com>  Thu, 26 Feb 2026 00:00:00 +0000

--- a/pkg/deb/debian/rules
+++ b/pkg/deb/debian/rules
@@ -20,7 +20,6 @@ override_dh_auto_build:
 	cp cron cron.pkg
 	sed -i 's|/usr/local/sbin/bfd|/usr/sbin/bfd|g' cron.pkg
 	cp cron.daily cron.daily.pkg
-	sed -i 's|INSTALL_PATH="$${INSTALL_PATH:-/usr/local/bfd}"|INSTALL_PATH="$${INSTALL_PATH:-/var/lib/bfd}"|' cron.daily.pkg
 	cp bfd.service bfd.service.pkg
 	sed -i 's|/usr/local/sbin/bfd|/usr/sbin/bfd|g' bfd.service.pkg
 	cp bfd-watch.service bfd-watch.service.pkg

--- a/pkg/rpm/bfd.spec
+++ b/pkg/rpm/bfd.spec
@@ -63,7 +63,6 @@ cp cron cron.pkg
 sed -i 's|/usr/local/sbin/bfd|/usr/sbin/bfd|g' cron.pkg
 
 cp cron.daily cron.daily.pkg
-sed -i 's|INSTALL_PATH="\${INSTALL_PATH:-/usr/local/bfd}"|INSTALL_PATH="${INSTALL_PATH:-/var/lib/bfd}"|' cron.daily.pkg
 
 cp bfd.service bfd.service.pkg
 sed -i 's|/usr/local/sbin/bfd|/usr/sbin/bfd|g' bfd.service.pkg

--- a/pkg/test/test-pkg-install.sh
+++ b/pkg/test/test-pkg-install.sh
@@ -165,10 +165,10 @@ echo ""
 # --- Test 4: Lock coordination ---
 echo "--- Test 4: Lock file coordination ---"
 cron_lock=$(grep 'INSTALL_PATH=' /etc/cron.daily/bfd | head -1)
-if echo "$cron_lock" | grep -q '/var/lib/bfd'; then
-	pass "cron.daily INSTALL_PATH defaults to /var/lib/bfd"
+if echo "$cron_lock" | grep -q '/usr/local/bfd'; then
+	pass "cron.daily INSTALL_PATH defaults to /usr/local/bfd"
 else
-	fail "cron.daily INSTALL_PATH does not default to /var/lib/bfd: $cron_lock"
+	fail "cron.daily INSTALL_PATH does not default to /usr/local/bfd: $cron_lock"
 fi
 echo ""
 
@@ -202,10 +202,10 @@ echo ""
 # --- Test 7b: Alert template files ---
 echo "--- Test 7b: Alert templates ---"
 tpl_count=$(find /usr/lib/bfd/alert/ -maxdepth 1 -name '*.tpl' -type f 2>/dev/null | wc -l)
-if [ "$tpl_count" -eq 14 ]; then
+if [ "$tpl_count" -eq 21 ]; then
 	pass "Alert template files present ($tpl_count templates)"
 else
-	fail "Expected 14 alert templates, found $tpl_count"
+	fail "Expected 21 alert templates, found $tpl_count"
 fi
 echo ""
 


### PR DESCRIPTION
## Summary

- **Fix cron.daily INSTALL_PATH in FHS packages** — RPM/DEB sed was transforming cron.daily's INSTALL_PATH to `/var/lib/bfd`, breaking conf.bfd sourcing, bfd execution, and ipcountry.dat refresh. Removed the transform; the symlink farm at `/usr/local/bfd` handles redirection.
- **Fix cron.daily lock detection in FHS packages** — source `internals.conf` (with ownership validation) so LOCK_FILE resolves to the FHS-transformed `/var/lib/bfd/lock.utime` instead of the non-existent `/usr/local/bfd/lock.utime`.
- **Add bfd_report.sh to CI lint targets** — was missing from `bash -n` and `shellcheck` steps.
- **Fix man page** — add `--ban`, `--unban`, `--events`, `--test` long forms; fix 5 template variable names; add `--sort`, `--limit`, `--24h/--7d/--30d`, `--active` to SYNOPSIS.
- **README restructure** — promote Periodic Reports from §7.1 subsection to top-level §8; renumber §8-12→§9-13; fix template variable table; update badges and description.
- **Source fixes** — split 87-char `usage_short()` line to 80 cols; add "and event view" to EMAIL_LOGLINES comment.
- **Package test assertions** — template count 14→21, DEB changelog rule count 42→57.

## Test plan

- [x] `bash -n` and `shellcheck -S warning` pass on all shell files
- [x] QA agent: APPROVED (all verification items pass)
- [x] Sentinel agent: PASS (0 MUST-FIX after lock detection fix)
- [ ] CI matrix (lint + 9-OS test + UAT)
- [x] Package install test (`pkg/test/test-pkg-install.sh`)